### PR TITLE
feat(boring): Add set_verify_cert_store_ref method to SslContextBuilder

### DIFF
--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -1163,6 +1163,19 @@ impl SslContextBuilder {
         }
     }
 
+    /// Sets a custom certificate store for verifying peer certificates.
+    #[corresponds(SSL_CTX_set1_verify_cert_store)]
+    pub fn set_verify_cert_store_ref(
+        &mut self,
+        cert_store: &'static X509Store,
+    ) -> Result<(), ErrorStack> {
+        unsafe {
+            cvt(ffi::SSL_CTX_set1_verify_cert_store(self.as_ptr(), cert_store.as_ptr()) as c_int)?;
+
+            Ok(())
+        }
+    }
+
     /// Replaces the context's certificate store.
     #[corresponds(SSL_CTX_set_cert_store)]
     pub fn set_cert_store(&mut self, cert_store: X509Store) {


### PR DESCRIPTION
This pull request introduces an enhancement to the `SslContextBuilder` in the `boring` crate to allow setting a custom certificate store for verifying peer certificates.

Enhancements to SSL context configuration:

* [`boring/src/ssl/mod.rs`](diffhunk://#diff-f941b07e398d4bfc3178d9fe4ca828cc49cccbac131b89e0fe5f14eec86e9c4bR1166-R1178): Added a new method `set_verify_cert_store_ref` to `SslContextBuilder` for setting a custom certificate store for verifying peer certificates. This method uses the `SSL_CTX_set1_verify_cert_store` function from the OpenSSL library.