### PR TITLE
Fix lifetimes in ssl::select_next_proto

### DIFF
--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -881,7 +881,7 @@ impl CompliancePolicy {
 ///
 /// [`SslContextBuilder::set_alpn_protos`]: struct.SslContextBuilder.html#method.set_alpn_protos
 #[corresponds(SSL_select_next_proto)]
-pub fn select_next_proto<'a>(server: &[u8], client: &'a [u8]) -> Option<&'a [u8]> {
+pub fn select_next_proto<'a>(server: &'a [u8], client: &'a [u8]) -> Option<&'a [u8]> {
     if server.is_empty() || client.is_empty() {
         return None;
     }


### PR DESCRIPTION
See https://github.com/sfackler/rust-openssl/pull/2360 and https://nvd.nist.gov/vuln/detail/CVE-2025-24898. From the rust-openssl PR:
> `SSL_select_next_proto` can return a pointer into either the client or server buffers, but the type signature of the function previously only bound the output buffer to the client buffer. This can result in a UAF in situations where the server slice does not point to a long-lived allocation.
Thanks to Matt Mastracci for reporting this issue.