### PR TITLE
fix(quinn-btls): Resolve panic in session_state and improve keys_updated signaling

### DIFF
--- a/quinn-btls/src/client/mod.rs
+++ b/quinn-btls/src/client/mod.rs
@@ -336,6 +336,8 @@ impl crypto::Session for Session {
             self.on_zero_rtt_rejected();
         }
 
+        let mut keys_updated = self.state.keys_updated;
+
         // Only indicate that handshake data is available once.
         // On the client side there is no ALPN callback, so we need to manually check
         // if the ALPN protocol has been selected.
@@ -346,11 +348,11 @@ impl crypto::Session for Session {
 
             if self.handshake_data_available {
                 self.handshake_data_sent = true;
-                return Ok(true);
+                keys_updated = true;
             }
         }
 
-        Ok(false)
+        Ok(keys_updated)
     }
 
     fn transport_parameters(&self) -> StdResult<Option<TransportParameters>, TransportError> {

--- a/quinn-btls/src/server/mod.rs
+++ b/quinn-btls/src/server/mod.rs
@@ -271,13 +271,15 @@ impl crypto::Session for Session {
     fn read_handshake(&mut self, plaintext: &[u8]) -> StdResult<bool, TransportError> {
         self.state.read_handshake(plaintext)?;
 
+        let mut keys_updated = self.state.keys_updated;
+
         // Only indicate that handshake data is available once.
         if !self.handshake_data_sent && self.handshake_data_available {
             self.handshake_data_sent = true;
-            return Ok(true);
+            keys_updated = true;
         }
 
-        Ok(false)
+        Ok(keys_updated)
     }
 
     fn transport_parameters(&self) -> StdResult<Option<TransportParameters>, TransportError> {

--- a/quinn-btls/src/session_state.rs
+++ b/quinn-btls/src/session_state.rs
@@ -41,7 +41,7 @@ pub(crate) struct SessionState {
     side: Side,
     alert: Option<TransportError>,
     next_secrets: Option<Secrets>,
-    keys_updated: bool,
+    pub(crate) keys_updated: bool,
     read_level: Level,
     write_level: Level,
     levels: [LevelState; Level::NUM_LEVELS],
@@ -186,13 +186,15 @@ impl SessionState {
                 let is_app = self.write_level == Level::Application;
 
                 // Build the secrets.
-                let secrets = self
-                    .level_state(self.write_level)
-                    .builder
-                    .build()
-                    .unwrap_or_else(|| {
-                        panic!("failed building secrets for level {:?}", self.write_level)
-                    });
+                let secrets = match self.level_state(self.write_level).builder.build() {
+                    Some(s) => s,
+                    None => {
+                        // Secrets are not buildable yet (likely one side of the secret is missing).
+                        // Keep keys_updated as true so that the next call to write_handshake will try again.
+                        self.keys_updated = true;
+                        return None;
+                    }
+                };
 
                 if is_app {
                     // We've transitioned to the application level, we need to set the


### PR DESCRIPTION
## Description
This PR addresses a critical panic in quinn-btls that occurs during the handshake process, particularly when the underlying secrets for the Application encryption level are not yet ready to be built.

## The Issue
The previous implementation used an .unwrap() (via unwrap_or_else with a panic message) in session_state.rs when building secrets. In certain environments or specific handshake sequences (observed during WebTransport sessions), BoringSSL may not have derived both halves of the secrets required for a specific level at the moment quinn attempts to transition. This led to a terminal panic: failed building secrets for level Application.

## Impact
Stability: Eliminates a major source of runtime crashes during connection establishment.
Correctness: Improves the accuracy of key-update signaling to the QUIC protocol implementation.