### PR TITLE
feat(btls-sys): ccache/sccache build acceleration

### DIFF
--- a/btls-sys/README.md
+++ b/btls-sys/README.md
@@ -12,13 +12,7 @@ To use BoringSSL from Rust, prefer the [higher-level safe API](https://docs.rs/b
 ## Speeding up the build
 
 Compiling BoringSSL from source is by far the most expensive part of building
-this crate. The build script applies two accelerations automatically:
-       
-- **Ninja generator.** When [`ninja`](https://ninja-build.org/) is found on the PATH, 
-  it is used instead of the default `make` generator. Ninja has lower
-  configure overhead and schedules the compile better. An explicit
-  `CMAKE_GENERATOR` is always respected, and Windows generator selection is left
-  untouched.
+this crate. The build script applies accelerations automatically:
 
 - **Compiler caching.** `RUSTC_WRAPPER` only caches `rustc`, so the ~370
   BoringSSL translation units are recompiled on every clean build even when

--- a/btls-sys/README.md
+++ b/btls-sys/README.md
@@ -14,7 +14,7 @@ To use BoringSSL from Rust, prefer the [higher-level safe API](https://docs.rs/b
 Compiling BoringSSL from source is by far the most expensive part of building
 this crate. The build script applies two accelerations automatically:
        
-- **Ninja generator.** When [`ninja`](https://ninja-build.org/) is found on 
+- **Ninja generator.** When [`ninja`](https://ninja-build.org/) is found on the PATH, 
   it is used instead of the default `make` generator. Ninja has lower
   configure overhead and schedules the compile better. An explicit
   `CMAKE_GENERATOR` is always respected, and Windows generator selection is left

--- a/btls-sys/README.md
+++ b/btls-sys/README.md
@@ -9,6 +9,33 @@ and [Raw Public Key](https://docs.rs/btls/latest/btls/ssl/struct.SslRef.html#met
 
 To use BoringSSL from Rust, prefer the [higher-level safe API](https://docs.rs/btls).
 
+## Speeding up the build
+
+Compiling BoringSSL from source is by far the most expensive part of building
+this crate. The build script applies two accelerations automatically:
+       
+- **Ninja generator.** When [`ninja`](https://ninja-build.org/) is found on 
+  it is used instead of the default `make` generator. Ninja has lower
+  configure overhead and schedules the compile better. An explicit
+  `CMAKE_GENERATOR` is always respected, and Windows generator selection is left
+  untouched.
+
+- **Compiler caching.** `RUSTC_WRAPPER` only caches `rustc`, so the ~370
+  BoringSSL translation units are recompiled on every clean build even when
+  [`sccache`](https://github.com/mozilla/sccache) or
+  [`ccache`](https://ccache.dev/) is configured.  
+  If `RUSTC_WRAPPER`/`RUSTC_WORKSPACE_WRAPPER` points at `sccache` or
+  `ccache` it is reused as-is; otherwise set `BORING_BSSL_COMPILER_LAUNCHER`
+  explicitly:
+
+  ```sh
+  # Reuse an existing sccache automatically:
+  export RUSTC_WRAPPER=sccache
+
+  # ...or point the BoringSSL build at a cache explicitly:
+  export BORING_BSSL_COMPILER_LAUNCHER=sccache
+  ```
+
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally

--- a/btls-sys/build/cache.rs
+++ b/btls-sys/build/cache.rs
@@ -3,13 +3,13 @@ use std::{ffi::OsString, path::Path};
 use crate::config::Config;
 
 pub fn apply(_config: &Config, cfg: &mut cmake::Config) {
-    try_enable_ccache(cfg);
+    try_enable_compiler_launcher(cfg);
 }
 
-fn try_enable_ccache(cfg: &mut cmake::Config) {
+fn try_enable_compiler_launcher(cfg: &mut cmake::Config) {
     if let Some(launcher) = compiler_launcher() {
         println!(
-            "cargo:warning=caching the BoringSSL C/C++ build with compiler launcher `{}`",
+            "cargo:warning=using compiler launcher `{}` for the BoringSSL C/C++ build",
             launcher.to_string_lossy()
         );
         cfg.define("CMAKE_C_COMPILER_LAUNCHER", &launcher);

--- a/btls-sys/build/cache.rs
+++ b/btls-sys/build/cache.rs
@@ -1,0 +1,45 @@
+use std::{ffi::OsString, path::Path};
+
+use crate::config::Config;
+
+pub fn apply(_config: &Config, cfg: &mut cmake::Config) {
+    try_enable_ccache(cfg);
+}
+
+fn try_enable_ccache(cfg: &mut cmake::Config) {
+    if let Some(launcher) = compiler_launcher() {
+        println!(
+            "cargo:warning=caching the BoringSSL C/C++ build with compiler launcher `{}`",
+            launcher.to_string_lossy()
+        );
+        cfg.define("CMAKE_C_COMPILER_LAUNCHER", &launcher);
+        cfg.define("CMAKE_CXX_COMPILER_LAUNCHER", &launcher);
+        cfg.define("CMAKE_ASM_COMPILER_LAUNCHER", &launcher);
+    }
+}
+
+fn compiler_launcher() -> Option<OsString> {
+    println!("cargo:rerun-if-env-changed=BORING_BSSL_COMPILER_LAUNCHER");
+    if let Some(launcher) =
+        std::env::var_os("BORING_BSSL_COMPILER_LAUNCHER").filter(|v| !v.is_empty())
+    {
+        return Some(launcher);
+    }
+
+    for var in ["RUSTC_WRAPPER", "RUSTC_WORKSPACE_WRAPPER"] {
+        println!("cargo:rerun-if-env-changed={var}");
+        let Some(wrapper) = std::env::var_os(var).filter(|v| !v.is_empty()) else {
+            continue;
+        };
+        let is_compiler_cache = Path::new(&wrapper)
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .is_some_and(|stem| {
+                stem.eq_ignore_ascii_case("sccache") || stem.eq_ignore_ascii_case("ccache")
+            });
+        if is_compiler_cache {
+            return Some(wrapper);
+        }
+    }
+    None
+}

--- a/btls-sys/build/main.rs
+++ b/btls-sys/build/main.rs
@@ -12,6 +12,7 @@ use std::sync::OnceLock;
 use crate::config::Config;
 use crate::prefix::{prefix_symbols, PrefixCallback};
 
+mod cache;
 mod config;
 mod prefix;
 
@@ -542,73 +543,6 @@ fn run_command(command: &mut Command) -> io::Result<Output> {
     Ok(out)
 }
 
-fn configure_build_acceleration(config: &Config, cfg: &mut cmake::Config) {
-    if let Some(generator) = preferred_cmake_generator(config) {
-        println!("cargo:warning=building BoringSSL with the {generator} generator");
-        cfg.generator(generator);
-    }
-
-    if let Some(launcher) = compiler_launcher() {
-        println!(
-            "cargo:warning=caching the BoringSSL C/C++ build with compiler launcher `{}`",
-            launcher.to_string_lossy()
-        );
-        cfg.define("CMAKE_C_COMPILER_LAUNCHER", &launcher);
-        cfg.define("CMAKE_CXX_COMPILER_LAUNCHER", &launcher);
-        cfg.define("CMAKE_ASM_COMPILER_LAUNCHER", &launcher);
-    }
-}
-
-fn compiler_launcher() -> Option<OsString> {
-    println!("cargo:rerun-if-env-changed=BORING_BSSL_COMPILER_LAUNCHER");
-    if let Some(launcher) =
-        std::env::var_os("BORING_BSSL_COMPILER_LAUNCHER").filter(|v| !v.is_empty())
-    {
-        return Some(launcher);
-    }
-
-    for var in ["RUSTC_WRAPPER", "RUSTC_WORKSPACE_WRAPPER"] {
-        println!("cargo:rerun-if-env-changed={var}");
-        let Some(wrapper) = std::env::var_os(var).filter(|v| !v.is_empty()) else {
-            continue;
-        };
-        let is_compiler_cache = Path::new(&wrapper)
-            .file_stem()
-            .and_then(|stem| stem.to_str())
-            .is_some_and(|stem| {
-                stem.eq_ignore_ascii_case("sccache") || stem.eq_ignore_ascii_case("ccache")
-            });
-        if is_compiler_cache {
-            return Some(wrapper);
-        }
-    }
-    None
-}
-
-fn preferred_cmake_generator(config: &Config) -> Option<&'static str> {
-    println!("cargo:rerun-if-env-changed=CMAKE_GENERATOR");
-
-    if std::env::var_os("CMAKE_GENERATOR").is_some() {
-        return None;
-    }
-
-    if config.target_os == "windows" {
-        return None;
-    }
-
-    is_program_available("ninja").then_some("Ninja")
-}
-
-fn is_program_available(program: &str) -> bool {
-    Command::new(program)
-        .arg("--version")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
-}
-
 fn build_boringssl_or_get_prebuilt(config: &Config) -> &Path {
     static BUILD_SOURCE_PATH: OnceLock<PathBuf> = OnceLock::new();
 
@@ -642,9 +576,10 @@ fn build_boringssl_or_get_prebuilt(config: &Config) -> &Path {
             cfg.define("CMAKE_POSITION_INDEPENDENT_CODE", "ON");
         }
 
-        configure_build_acceleration(config, &mut cfg);
+        cache::apply(config, &mut cfg);
 
         cfg.build_target("ssl").build();
+        // skip re-running cmake configure for the next target
         cfg.always_configure(false);
         let path = cfg.build_target("crypto").build();
         let build_dir = path.join("build");

--- a/btls-sys/build/main.rs
+++ b/btls-sys/build/main.rs
@@ -542,6 +542,72 @@ fn run_command(command: &mut Command) -> io::Result<Output> {
     Ok(out)
 }
 
+fn configure_build_acceleration(config: &Config, cfg: &mut cmake::Config) {
+    if let Some(generator) = preferred_cmake_generator(config) {
+        println!("cargo:warning=building BoringSSL with the {generator} generator");
+        cfg.generator(generator);
+    }
+
+    if let Some(launcher) = compiler_launcher() {
+        println!(
+            "cargo:warning=caching the BoringSSL C/C++ build with compiler launcher `{}`",
+            launcher.to_string_lossy()
+        );
+        cfg.define("CMAKE_C_COMPILER_LAUNCHER", &launcher);
+        cfg.define("CMAKE_CXX_COMPILER_LAUNCHER", &launcher);
+    }
+}
+
+fn compiler_launcher() -> Option<OsString> {
+    println!("cargo:rerun-if-env-changed=BORING_BSSL_COMPILER_LAUNCHER");
+    if let Some(launcher) =
+        std::env::var_os("BORING_BSSL_COMPILER_LAUNCHER").filter(|v| !v.is_empty())
+    {
+        return Some(launcher);
+    }
+
+    for var in ["RUSTC_WRAPPER", "RUSTC_WORKSPACE_WRAPPER"] {
+        println!("cargo:rerun-if-env-changed={var}");
+        let Some(wrapper) = std::env::var_os(var).filter(|v| !v.is_empty()) else {
+            continue;
+        };
+        let is_compiler_cache = Path::new(&wrapper)
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .is_some_and(|stem| {
+                stem.eq_ignore_ascii_case("sccache") || stem.eq_ignore_ascii_case("ccache")
+            });
+        if is_compiler_cache {
+            return Some(wrapper);
+        }
+    }
+    None
+}
+
+fn preferred_cmake_generator(config: &Config) -> Option<&'static str> {
+    println!("cargo:rerun-if-env-changed=CMAKE_GENERATOR");
+
+    if std::env::var_os("CMAKE_GENERATOR").is_some() {
+        return None;
+    }
+
+    if config.target_os == "windows" {
+        return None;
+    }
+
+    is_program_available("ninja").then_some("Ninja")
+}
+
+fn is_program_available(program: &str) -> bool {
+    Command::new(program)
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
 fn build_boringssl_or_get_prebuilt(config: &Config) -> &Path {
     static BUILD_SOURCE_PATH: OnceLock<PathBuf> = OnceLock::new();
 
@@ -575,7 +641,10 @@ fn build_boringssl_or_get_prebuilt(config: &Config) -> &Path {
             cfg.define("CMAKE_POSITION_INDEPENDENT_CODE", "ON");
         }
 
+        configure_build_acceleration(config, &mut cfg);
+
         cfg.build_target("ssl").build();
+        cfg.always_configure(false);
         let path = cfg.build_target("crypto").build();
         let build_dir = path.join("build");
         if build_dir.exists() {

--- a/btls-sys/build/main.rs
+++ b/btls-sys/build/main.rs
@@ -579,8 +579,6 @@ fn build_boringssl_or_get_prebuilt(config: &Config) -> &Path {
         cache::apply(config, &mut cfg);
 
         cfg.build_target("ssl").build();
-        // skip re-running cmake configure for the next target
-        cfg.always_configure(false);
         let path = cfg.build_target("crypto").build();
         let build_dir = path.join("build");
         if build_dir.exists() {

--- a/btls-sys/build/main.rs
+++ b/btls-sys/build/main.rs
@@ -555,6 +555,7 @@ fn configure_build_acceleration(config: &Config, cfg: &mut cmake::Config) {
         );
         cfg.define("CMAKE_C_COMPILER_LAUNCHER", &launcher);
         cfg.define("CMAKE_CXX_COMPILER_LAUNCHER", &launcher);
+        cfg.define("CMAKE_ASM_COMPILER_LAUNCHER", &launcher);
     }
 }
 


### PR DESCRIPTION
BoringSSL takes a long time to build from source. This PR adds heuristics to automatically wire up `sccache`/`ccache` for the C/C++ translation units if they are already used for Rust via `RUSTC_WRAPPER`.

Changes:
- Detect `sccache`/`ccache` from `RUSTC_WRAPPER` or `BORING_BSSL_COMPILER_LAUNCHER` and pass them via `CMAKE_{C,CXX}_COMPILER_LAUNCHER`.

Local benchmarks (`cargo build -p btls-sys`):
- baseline: 21-22s
- sccache first: 19-20s
- sccache (warm): 13-14s

